### PR TITLE
Workaround for a curses error on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ $ git clone https://github.com/rr-/pq-cli.git
 $ cd pq-cli
 $ pip install --user .
 ```
+
+## Troubleshooting
+
+### `_curses.error: init_pair() returned ERR`
+
+If running on Linux and you get the error `_curses.error: init_pair() returned ERR`,
+try making sure that your `$TERM` variable is set to a value which supports
+256 colors, such as via the following:
+
+    TERM=xterm-256color pqcli
+


### PR DESCRIPTION
Ran into this issue today when I gave this a go -- I don't really think it's worth trying to figure out a code workaround for this, but having a note in the README could potentially help other Linux users if they run into the same problem.

If this is something you don't mind having in the README but would like things phrased/arranged differently, let me know and I'd be happy to reword and move things around.

Thanks regardless for this port!  I'd always wanted a PQ that I could just run in a screen/tmux somewhere, but I think the last time I'd checked (ages ago, by now), PQ itself hadn't been opensourced yet.