### PR TITLE
fix seed type issue

### DIFF
--- a/pqcli/mechanic.py
+++ b/pqcli/mechanic.py
@@ -922,7 +922,7 @@ def create_player(
     name: str, race: Race, class_: Class, stats: Stats
 ) -> Player:
     now = datetime.datetime.now()
-    random.seed(now)
+    random.seed(str(now))
     player = Player(
         birthday=now, name=name, race=race, class_=class_, stats=stats
     )


### PR DESCRIPTION
Currently, if one try to create a new player they get the following error:
```
(pqcli-py3.11) ~/src/pq-cli $ poetry run pqcli/
Traceback (most recent call last):
  File "/home/anakojm/.cache/pypoetry/virtualenvs/pqcli-u5jlEZAV-py3.11/bin/pqcli", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/anakojm/src/pq-cli/pqcli/__main__.py", line 88, in main
    ui.run()
  File "/home/anakojm/src/pq-cli/pqcli/ui/curses/__init__.py", line 100, in run
    self._view.keypress(key)
  File "/home/anakojm/src/pq-cli/pqcli/ui/curses/views/create_character_view/choose_character_stats_view.py", line 58, in keypress
    self.on_confirm(self._stats)
  File "/home/anakojm/src/pq-cli/pqcli/ui/curses/event_handler.py", line 10, in __call__
    callback(*args, **kwargs)
  File "/home/anakojm/src/pq-cli/pqcli/ui/curses/__init__.py", line 152, in <lambda>
    view.on_confirm += lambda stats: self._create_character(
                                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anakojm/src/pq-cli/pqcli/ui/curses/__init__.py", line 192, in _create_character
    player = create_player(name, race, class_, stats)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anakojm/src/pq-cli/pqcli/mechanic.py", line 925, in create_player
    random.seed(now)
  File "/home/anakojm/src/pq-cli/pqcli/random.py", line 6, in seed
    random.seed(source)
  File "/usr/lib/python3.11/random.py", line 160, in seed
    raise TypeError('The only supported seed types are: None,\n'
TypeError: The only supported seed types are: None,
int, float, str, bytes, and bytearray.
```
This PR gives the type `string` to the variable `now` before passing it to `random.seed()` in order to adress this issue.