### PR TITLE
Fixed crash on Linux due to zero length addnstr call

### DIFF
--- a/pqcli/ui/curses/views/game_view/progress_bar_window.py
+++ b/pqcli/ui/curses/views/game_view/progress_bar_window.py
@@ -65,22 +65,16 @@ class ProgressBarWindow(WindowWrapper):
 
             text = self._progress_title
             x = max(0, (self.getmaxyx()[1] - len(text)) // 2)
-
             # Determine the number of characters to write
-
             nwrite = min(len(text), self._progress_bar_win.getmaxyx()[1])
-
             # The amount MUST be greater than zero to avoid linux errors
-
             if nwrite > 0:
-
                 self._progress_bar_win.addnstr(
                     0,
                     x,
                     text,
                     nwrite,
                 )
-
         self._progress_bar.set_position(self._cur_pos, self._max_pos)
         self._progress_bar_win.noutrefresh()
 

--- a/pqcli/ui/curses/views/game_view/progress_bar_window.py
+++ b/pqcli/ui/curses/views/game_view/progress_bar_window.py
@@ -65,12 +65,21 @@ class ProgressBarWindow(WindowWrapper):
 
             text = self._progress_title
             x = max(0, (self.getmaxyx()[1] - len(text)) // 2)
-            self._progress_bar_win.addnstr(
-                0,
-                x,
-                text,
-                min(len(text), self._progress_bar_win.getmaxyx()[1]),
-            )
+
+            # Determine the number of characters to write
+
+            nwrite = min(len(text), self._progress_bar_win.getmaxyx()[1])
+
+            # The amount MUST be greater than zero to avoid linux errors
+
+            if nwrite > 0:
+
+                self._progress_bar_win.addnstr(
+                    0,
+                    x,
+                    text,
+                    nwrite,
+                )
 
         self._progress_bar.set_position(self._cur_pos, self._max_pos)
         self._progress_bar_win.noutrefresh()


### PR DESCRIPTION
When `addnstr` is called with a size of zero on Linux (in my case, Arch Linux), weird behavior occurs. In this case, the program will crash after a profile is selected and the main game UI is initialized. Adding a simple check to see if the number of characters to add is greater than zero before calling `addnstr` fixes the problem. This fixes the problem documented in this issue:

https://github.com/rr-/pq-cli/issues/23

This was tested on both Linux and windows, and the only issue I see is the character sheet pad is broken (see 2nd PR).

Let me know if anything needs to be changed!