### PR TITLE
Fixed empty character sheet on Linux

### DIFF
--- a/pqcli/ui/curses/widgets/data_table.py
+++ b/pqcli/ui/curses/widgets/data_table.py
@@ -69,13 +69,9 @@ class DataTable(Scrollable):
                 if y == self._selected and has_colors():
                     self._pad.attron(curses.color_pair(COLOR_HIGHLIGHT))
                 self._pad.addnstr(y, 0, row[0], min(len(row[0]), w))
-
                 # Determine the number of characters to write
-
                 nwrite = min(len(row[1]), w - col2_x)
-
                 # Ensure we have enough columns, and we are writing more than zero
-
                 if col2_x < w and nwrite > 0:
                     self._pad.addnstr(y, col2_x, row[1], nwrite)
                 if y == self._selected and has_colors():

--- a/pqcli/ui/curses/widgets/data_table.py
+++ b/pqcli/ui/curses/widgets/data_table.py
@@ -69,10 +69,15 @@ class DataTable(Scrollable):
                 if y == self._selected and has_colors():
                     self._pad.attron(curses.color_pair(COLOR_HIGHLIGHT))
                 self._pad.addnstr(y, 0, row[0], min(len(row[0]), w))
-                if col2_x < w:
-                    self._pad.addnstr(
-                        y, col2_x, row[1], min(len(row[1]), w - col2_x)
-                    )
+
+                # Determine the number of characters to write
+
+                nwrite = min(len(row[1]), w - col2_x)
+
+                # Ensure we have enough columns, and we are writing more than zero
+
+                if col2_x < w and nwrite > 0:
+                    self._pad.addnstr(y, col2_x, row[1], nwrite)
                 if y == self._selected and has_colors():
                     self._pad.attroff(curses.color_pair(COLOR_HIGHLIGHT))
 


### PR DESCRIPTION
When `addnstr` is called with a size of zero on Linux (in my case, Arch Linux), weird behavior occurs. In this case, the character sheet is empty and does not display any information. Adding a check to see if the number of characters to be add is greater than zero before calling `addnstr` fixes the problem.

This was tested on both Linux and windows, and I was unable to find any visual problems introduced by this PR.

Let me know if anything needs to be changed!